### PR TITLE
Updates and new Core uploader

### DIFF
--- a/015-Serverless/Tollbooth/TollBooth/TollBooth.sln
+++ b/015-Serverless/Tollbooth/TollBooth/TollBooth.sln
@@ -1,11 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2026
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30611.23
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TollBooth", "TollBooth\TollBooth.csproj", "{C685154D-E224-46AA-87BB-A87ED30B0121}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UploadImages", "UploadImages\UploadImages.csproj", "{A7110625-77CF-45DD-920F-F35E8A4740BB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UploadImagesCore", "UploadImagesCore\UploadImagesCore.csproj", "{632F2C3E-902E-48BD-9AD0-85C565201E8C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +23,10 @@ Global
 		{A7110625-77CF-45DD-920F-F35E8A4740BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A7110625-77CF-45DD-920F-F35E8A4740BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A7110625-77CF-45DD-920F-F35E8A4740BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{632F2C3E-902E-48BD-9AD0-85C565201E8C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{632F2C3E-902E-48BD-9AD0-85C565201E8C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{632F2C3E-902E-48BD-9AD0-85C565201E8C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{632F2C3E-902E-48BD-9AD0-85C565201E8C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/015-Serverless/Tollbooth/TollBooth/TollBooth/FileMethods.cs
+++ b/015-Serverless/Tollbooth/TollBooth/TollBooth/FileMethods.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -40,7 +41,7 @@ namespace TollBooth
             using (var stream = new MemoryStream())
             {
                 using (var textWriter = new StreamWriter(stream))
-                using (var csv = new CsvWriter(textWriter))
+                using (var csv = new CsvWriter(textWriter, CultureInfo.CurrentCulture))
                 {
                     csv.Configuration.Delimiter = ",";
                     csv.WriteRecords(licensePlates.Select(ToLicensePlateData));

--- a/015-Serverless/Tollbooth/TollBooth/TollBooth/TollBooth.csproj
+++ b/015-Serverless/Tollbooth/TollBooth/TollBooth/TollBooth.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="12.1.2" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.6.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.8" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
-    <PackageReference Include="Polly" Version="7.1.1" />
+    <PackageReference Include="CsvHelper" Version="15.0.8" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.12.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventGrid" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.3" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
+    <PackageReference Include="Polly" Version="7.2.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/015-Serverless/Tollbooth/TollBooth/UploadImagesCore/Program.cs
+++ b/015-Serverless/Tollbooth/TollBooth/UploadImagesCore/Program.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Configuration;
+using System.Net;
+using Microsoft.Azure.Storage;
+using Microsoft.Azure.Storage.Blob;
+using Microsoft.Azure.Storage.DataMovement;
+
+namespace UploadImagesCore
+{
+    class Program
+    {
+        private static List<MemoryStream> _sourceImages;
+        private static readonly Random Random = new Random();
+        private static string BlobStorageConnection;
+
+        static int Main(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                Console.WriteLine("You must pass the Blob Storage connection string as an argument when executing this application.");
+                Console.ReadLine();
+                return 1;
+            }
+            else
+            {
+                BlobStorageConnection = args[0];
+            }
+
+            int choice = 1;
+            Console.WriteLine("Enter one of the following numbers to indicate what type of image upload you want to perform:");
+            Console.WriteLine("\t1 - Upload a handful of test photos");
+            Console.WriteLine("\t2 - Upload 1000 photos to test processing at scale");
+            int.TryParse(Console.ReadLine(), out choice);
+
+            bool upload1000 = choice == 2;
+
+            UploadImages(upload1000);
+
+            Console.ReadLine();
+
+            return 0;
+        }
+
+        private static void UploadImages(bool upload1000)
+        {
+            Console.WriteLine("Uploading images");
+            int uploaded = 0;
+            var account = CloudStorageAccount.Parse(BlobStorageConnection);
+            var blobClient = account.CreateCloudBlobClient();
+            var blobContainer = blobClient.GetContainerReference("images");
+            blobContainer.CreateIfNotExists();
+
+            // Setup the number of the concurrent operations.
+            TransferManager.Configurations.ParallelOperations = 64;
+            // Set ServicePointManager.DefaultConnectionLimit to the number of eight times the number of cores.
+            ServicePointManager.DefaultConnectionLimit = Environment.ProcessorCount * 8;
+            ServicePointManager.Expect100Continue = false;
+            // Setup the transfer context and track the upload progress.
+            //var context = new SingleTransferContext
+            //{
+            //    ProgressHandler =
+            //        new Progress<TransferStatus>(
+            //            (progress) => { Console.WriteLine("Bytes uploaded: {0}", progress.BytesTransferred); })
+            //};
+
+            if (upload1000)
+            {
+                LoadImagesFromDisk(true);
+                for (var i = 0; i < 200; i++)
+                {
+                    foreach (var image in _sourceImages)
+                    {
+                        var filename = GenerateRandomFileName();
+                        var destBlob = blobContainer.GetBlockBlobReference(filename);
+
+                        var task = TransferManager.UploadAsync(image, destBlob);
+                        task.Wait();
+                        uploaded++;
+                        Console.WriteLine($"Uploaded image {uploaded}: {filename}");
+                    }
+                }
+            }
+            else
+            {
+                LoadImagesFromDisk(false);
+                foreach (var image in _sourceImages)
+                {
+                    var filename = GenerateRandomFileName();
+                    var destBlob = blobContainer.GetBlockBlobReference(filename);
+
+                    var task = TransferManager.UploadAsync(image, destBlob);
+                    task.Wait();
+                    uploaded++;
+                    Console.WriteLine($"Uploaded image {uploaded}: {filename}");
+                }
+            }
+
+            Console.WriteLine("Finished uploading images");
+        }
+
+        private static string GenerateRandomFileName()
+        {
+            const int randomStringLength = 8;
+            const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+            var rando = new string(Enumerable.Repeat(chars, randomStringLength)
+              .Select(s => s[Random.Next(s.Length)]).ToArray());
+            return $"{rando}.jpg";
+        }
+
+        private static void LoadImagesFromDisk(bool upload1000)
+        {
+            // This loads the images to be uploaded from disk into memory.
+            if (upload1000)
+            {
+                _sourceImages =
+                    Directory.GetFiles(@"..\..\..\..\..\license plates\copyfrom\")
+                        .Select(f => new MemoryStream(File.ReadAllBytes(f)))
+                        .ToList();
+            }
+            else
+            {
+                _sourceImages =
+                    Directory.GetFiles(@"..\..\..\..\..\license plates\")
+                        .Select(f => new MemoryStream(File.ReadAllBytes(f)))
+                        .ToList();
+            }
+        }
+    }
+}

--- a/015-Serverless/Tollbooth/TollBooth/UploadImagesCore/UploadImagesCore.csproj
+++ b/015-Serverless/Tollbooth/TollBooth/UploadImagesCore/UploadImagesCore.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Storage.DataMovement" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Updated the TollBooth application to .NET Core 3.1 to remove some friction during the hack since Functions are now 3.1 by default.
Added a Core version of UploadImages for Mac and Linux users.