### PR TITLE
Refactored IntrotoKubernetes Ch 10 Networking

### DIFF
--- a/001-IntroToKubernetes/Coach/10-networking.md
+++ b/001-IntroToKubernetes/Coach/10-networking.md
@@ -8,9 +8,6 @@
 - The Ingress Controller has many capabilities, students are going to experiment only with its DNS routing capability in this challenge
 - Make sure that each student's AKS cluster has the nginx Ingress Controller installed. They should eventually find this page that is a step by step walkthrough on installing the nginx Ingress Controller on an AKS cluster:
 	- <https://docs.microsoft.com/en-us/azure/aks/ingress-basic>
-- Refer to the AKS documentation for the verification of logs
-- Validate DNS entries in the portal by navigating to the "special" `MC_xxx` resource group created for each AKS cluster and find the **DNS Zone** object in there.
-	- **NOTE**: The DNS entries are **NOT** required but encouraged to be in the "special" resource group. The students will deploy a **DNS Zone** into the resource group of their choice after installing the Ingress Controller.
-- The documentation below contains a section "Add an A record to your DNS zone". This is how the students will add the Ingress Controller external IP to their DNS zone.
-	- <https://docs.microsoft.com/en-us/azure/aks/ingress-tls>
-- In `template-web-ingress-deploy.yml` the host name should be changed to "name-of-ingress-controller.MY_CUSTOM_DOMAIN"
+- Regarding the question _"Discuss with your coach how you might link a 'real' DNS name (eg, conferenceinfo.fabmedical.com) with this "azure-specific" DNS name (eg, conferenceinfo.eastus.cloudapp.azure.com)"_, the answer is, use a CNAME.
+  - eg, in your DNS system of record, you would set conferenceinfo.fabmedical.com as a CNAME pointing to conferenceinfo.eastus.cloudapp.azure.com
+- Optionally, if the coach has access to a valid (personal) domain, they could demonstrate setting up the CNAME for the students.

--- a/001-IntroToKubernetes/README.md
+++ b/001-IntroToKubernetes/README.md
@@ -1,10 +1,10 @@
-# What The Hack - Intro To Kubernetes
+# Intro To Kubernetes & AKS Hack
 ## Introduction
 This intro level hack will help you get hands-on experience with Docker, Kubernetes and the Azure Kubernetes Service (AKS) on Microsoft Azure. Kubernetes has quickly gone from being the shiny new kid on the block to the defacto way to deploy and orchestrate containerized applications.
 
 This hack starts off by covering containers, what problems they solve, and why Kubernetes is needed to help orchestrate them.  You will learn all of the Kubernetes jargon (pods, services, and deployments, oh my!).  By the end, you should have a good understanding of what Kubernetes is and be familiar with how to run it on Azure.
 
-This hack includes a optional [lecture presentation](Coach/Lectures.pptx) that features short presentations to introduce key topics associated with each challenge. It is recommended that the host present each short presentation before attendees kick off that challenge.
+This hack includes optional lectures in the Coach/Lectures folder that features short presentations to introduce key topics associated with each challenge. It is recommended that the host present each short presentation before attendees kick off that challenge.
 
 ## Learning Objectives
 In this hack you will solve a common challenge for companies migrating to the cloud. You will take a simple multi-tiered web app, containerize it, and deploy it to an AKS cluster. Once the application is in AKS, you will learn how to tweak all the knobs and levers to scale, manage and monitor it.
@@ -34,8 +34,8 @@ In this hack you will solve a common challenge for companies migrating to the cl
    - Delete the MongoDB you created earlier and observe what happens when you don't have persistent storage. Fix it!
 - Challenge 9: **[Helm](Student/09-helm.md)**
    - Install Helm tools, customize a sample Helm package to deploy FabMedical, publish the Helm package to Azure Container Registry and use the Helm package to redeploy FabMedical to AKS.
-- Challenge 10: **[Networking](Student/10-networking.md)**
-   - Explore different ways of routing traffic to FabMedical by configuring an Ingress Controller with the HTTP Application Routing feature in AKS.
+- Challenge 10: **[DNS & Ingress](Student/10-networking.md)**
+   - Explore integrating DNS with Kubernetes services, and explore different ways of routing traffic to FabMedical by configuring an Ingress Controller.
 - Challenge 11: **[Operations and Monitoring](Student/11-opsmonitoring.md)**
    - Explore the logs provided by Kubernetes using the Kubernetes CLI, configure Azure Monitor and build a dashboard that monitors your AKS cluster
    
@@ -52,15 +52,13 @@ In this hack you will solve a common challenge for companies migrating to the cl
 - [**Visual Studio Code**](https://code.visualstudio.com/)
 
 ## Repository Contents
-- `../Coach/Guides`
-  - [Lecture presentation](Coach/Lectures.pptx) with short presentations to introduce each challenge.
+- `../Coach/[Guides]`
+  - `../Coach/Lectures`
 - `../Coach/Solutions`
    - Example solutions to the challenges (If you're a student, don't cheat yourself out of an education!)
 - `../Student/Resources`
    - FabMedial app code and sample templates to aid with challenges
 
+
 ## Contributors
-- Peter Laudati
-- Gino Filicetti
-- Israel Ekpo
-- Sowmyan Soman Chullikkattil
+Mostly based on topics from [What the Hack](https://github.com/microsoft/WhatTheHack).  Modified/updated by Larry Claman.

--- a/001-IntroToKubernetes/Student/10-networking.md
+++ b/001-IntroToKubernetes/Student/10-networking.md
@@ -1,23 +1,52 @@
-# Challenge 10: Networking
+# Challenge 10: DNS & Ingress
 
 [< Previous Challenge](./09-helm.md) - **[Home](../README.md)** - [Next Challenge >](./11-opsmonitoring.md)
 
 ## Introduction
 
-We started out with some very simple, default networking that Kubernetes gives us for free. But this is rarely what we'll need to go into production. Now we'll get a little more in depth on networking in Kubernetes
+We started out with some very simple, default networking that Kubernetes gives us for free. But this is rarely what we'll need to go into production. Now we'll get a little more in depth on networking in Kubernetes, and investigate DNS as well as Ingress Controllers.
 
 ## Description
 
-In this challenge you will be installing an Ingress Controller and learning how the "Ingress" resource in Kubernetes works. 
+In this challenge you will be enabling DNS, installing an Ingress Controller and learning how the "Ingress" resource in Kubernetes works. 
 
-- Delete the existing content-web deployment and service.
-- Install the nginx ingress controller.
-- Create a DNS Zone for the AKS cluster.
-- Deploy the content-web service and create an Ingress resource for it. 
+Note:  This challenge will be a bit more "guided" than the others.   While these features are straightforward to implement (as you will see), it would be quite challenging (no pun intended) to get them working in a short period of time with just a "read the docs" approach.
+
+## Part 1:  DNS for Public IPs
+In the previous challenges, we accessed our service via an IP address.  What if you want to use a DNS name to reach the service?  That's possible using the following method:
+
+1. Add the following metadata annotation to your content-web service:  (see [this link](https://docs.microsoft.com/en-us/azure/aks/static-ip#apply-a-dns-label-to-the-service) for more detail)
+```
+metadata:
+  annotations:
+    service.beta.kubernetes.io/azure-dns-label-name: myserviceuniquelabel
+```
+2. Your service should now be available at the url http://[myserviceuniquelabel].[location].cloudapp.azure.com.   
+3. Verify that the DNS record has been created (nslookup or dig), and then test this url in your browser.
+4. Discuss with your coach how you might link a 'real' DNS name (eg, conferenceinfo.fabmedical.com) with this "azure-specific" DNS name (eg, conferenceinfo.eastus.cloudapp.azure.com)
+
+## Part 2a: Ingress Controller
+Switching gears, we will now start working with ingress controllers, which allow you to route http requests.
+
+1. Delete the existing content-web service.
+2. Install the nginx ingress controller using helm. See https://docs.microsoft.com/en-us/azure/aks/ingress-basic for instructions.
+3. Deploy the content-web service and create an Ingress resource for it. 
 	- The reference template can be found in the Challenge 10 Resources folder: `template-web-ingress-deploy.yaml`
-	- Change the ACR & AKS DNS Name to match yours.
-- Verify the DNS records are created, and if so, access the application using the DNS name, e.g: 
-    - `http://fabmed.[YOUR_AKS_DNS_ID].[REGION].aksapp.io`
+
+## Part 2b: Ingress Controller + DNS for Public IPs
+Just like in part 1, you will now add a metadata annotation to the ingress controller to configure a dns name.
+
+1. Adding a dns label to the ingress controller via helm can be tricky.  It's documented at this link: https://docs.microsoft.com/en-us/azure/aks/ingress-static-ip
+   - Specifically, you will need to modify (upgrade) your ingress controller deployment as follows:
+```
+helm upgrade  nginx-ingress ingress-nginx/ingress-nginx \
+    --namespace ingress-basic --reuse-values \
+    --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-dns-label-name"="NEW-DNS-LABEL"
+```
+2. Next, you should update the ingress yaml you created earlier by uncommenting the `Host:` line and adding in the DNS_LABEL you chose.
+3. Verify that the DNS record has been created (nslookup or dig), and then access the application using the DNS name, e.g: 
+    - `http://[new-dns-label].[REGION].cloudapp.azure.com`
+
 
 ## Success Criteria
 

--- a/001-IntroToKubernetes/Student/Resources/Challenge 10/template-web-ingress-deploy.yml
+++ b/001-IntroToKubernetes/Student/Resources/Challenge 10/template-web-ingress-deploy.yml
@@ -1,26 +1,3 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: web
-spec:
-  selector:
-    matchLabels:
-      app: web  
-  template:
-    metadata:
-      labels:
-        app: web
-    spec:
-      containers:
-      - image: YOUR_ACR_NAME.azurecr.io/content-web
-        name: web
-        env:
-        - name: CONTENT_API_URL
-          value: http://api:3001
-        tty: true
-        ports:
-        - containerPort: 3000
----
 apiVersion: v1
 kind: Service
 metadata:
@@ -31,7 +8,7 @@ spec:
     protocol: TCP
     targetPort: 3000
   selector:
-    app: web
+    app: content-web
   type: ClusterIP
 ---
 apiVersion: extensions/v1beta1
@@ -42,10 +19,10 @@ metadata:
     kubernetes.io/ingress.class: nginx
 spec:
   rules:
-  - host: YOUR_AKS_CLUSTER_NAME.YOUR_AKS_DNS_ID.YOUR_AKS_REGION.aksapp.io
-    http:
+  - http:
       paths:
       - backend:
           serviceName: web
           servicePort: 80
         path: /
+#    host: <myserviceuniquelabel>.<location>.cloudapp.azure.com  # Leave this line commented out until Part 2b


### PR DESCRIPTION
This is a significant rewrite of Ch10 Networking

- First, I renamed it "DNS and Ingress" because it's not really about networking.  (#featurerequest:  Network policy would make a great addition to the 023 Advanced Kubernetes hack 😎)
- Second, I removed all references to the 'http-routing-addon'.  Given that the official guidance is that the http-routing-addon (direct quite) 'is not currently designed for use in a production environment and is not recommended for production use', I don't think it should be part of any hack designed to teach customers how to operate their production environment.
- Third, I refactored the flow of the hack to first cover DNS, then to cover the ingress controller.

You will see that the DNS integration techniques I use work well, but they are unfortunately poorly documented (at the time of this writing).  Thus, I took an approach where this challenge is much more guided than the other challenges.  This is because, in my opinion, it would not be feasible to expect that students new to AKS would be able to solve this challenge on their own.