### PR TITLE
Update to Introtok8s Ch01 Containers

### DIFF
--- a/001-IntroToKubernetes/Coach/01-containers.md
+++ b/001-IntroToKubernetes/Coach/01-containers.md
@@ -4,6 +4,12 @@
 
 ## Notes & Guidance
 
+**NOTE TO COACH: Timebox this challenge!**  It is easy for students/teams to get stuck and spend multiple hours on this challenge, which takes away precious time that could be spent on Kubernetes challenges.  I suggest limiting this to one hour at most.  After that time has been reached, show the students how to run `az acr import` to pull the existing images from dockerhub into their ACR in challenge 2.
+
+##############
+
+
+
 - Deploy build machine VM with Linux + Docker using provided ARM Template
 	- **`az group create -g <resourcegroupname> -l <region>`**
 	- **`az deployment group create -g <rgname> -n <deploymentName> --template-file docker-build-machine-vm.json --parameters docker-build-machine-vm.parameters.json`**

--- a/001-IntroToKubernetes/Student/01-containers.md
+++ b/001-IntroToKubernetes/Student/01-containers.md
@@ -6,45 +6,47 @@
 
 The first step in our journey will be to take our application and package it as a container image using Docker.
 
+## Demo
+Your coach will demonstrate running the application natively without using containers.
+
 ## Description
 
-In this challenge we'll be building and running the node.js based FabMedical app locally on our machines to see it working. Then we'll be creating Dockerfiles to build a container image of our app.
+In this challenge we'll use a Dockerfiles to build container images of our app, and we'll test them locally.
 
-- Deploy build machine VM with Linux + Docker using provided ARM Template and parameters file in the "Files" tab of the Team's General channel. Run the Fab Medical application locally on the VM and verify access
-	- **NOTE:** To ssh into the build machine using port 2266 on the VMs public IP:
-    	- `ssh -p 2266 wthadmin@12.12.12.12` 
-	- Each part of the app (api and web) runs independently.
-	- Build the API app by navigating to the content-api folder and run `npm install`.
-	- To start the app, run `node ./server.js &`
-	- Verify the API app runs by hitting its URL with one of the three function names. Eg: **<http://localhost:3001/speakers>**
-	- Repeat for the steps above for the content-web app, but verify it's available via a browser on the Internet!
-	- **NOTE:** The content-web app expects an environment variable named `CONTENT_API_URL` that points to the API app's URL. 
-- Create a Dockerfile for the content-api app that will:
-	- Create a container based on the **node:8** container image
-	- Build the Node application like you did above (Hint: npm install)
-	- Exposes the needed port
-	- Starts the node application
-- Create a Dockerfile for the content-web app that will:
-	- Do the same as the Dockerfile for the content-api
-	- Also sets the environment variable value as above
-- Build Docker images for both content-api and content-web
-- Run both containers you just built and verify that it is working. 
+Choice:  you can choose to build the docker images locally on your workstation, or you can deploy a linux VM in Azure to act as your build server.
+
+### Deploying and Access a Linux VM Build Server
+If you choose to use a VM in Azure, deploy the build machine VM with Linux + Docker using the provided ARM Template and parameters file in the "Student/Resources/Chapter 1/build-machine" folder of this repo.  You can run the following script:
+```
+RG="akshack-RG" 
+LOCATION="EastUS"  # Change as appropriate
+az group create --name $RG --location $LOCATION
+az deployment group create --name buildvmdeployment -g $RG \
+    -f docker-build-machine-vm.json \
+	-p docker-build-machine-vm.parameters.json
+```
+You will then need to ssh into the machine (which is using port 2266):
+
+`ssh -p 2266 wthadmin@12.12.12.12 # replace 12.12.12.12 with the public IP of the vm`
+
+(Alternatively, you can use the VSCode Remote Shell extension to remotely access the VM)
+
+### Building the Docker Image
+Our Fab Medical App consists of two components, a web component and an api component.  Your task is to build containers for each of these.  You have been provided source code (no need to edit) and a Docker file for each.
+
+### Success Criteria
+- Build Docker images for both `content-api` and `content-web`
+- Run both containers you just built and verify that the app is working. 
 	- **Hint:** Run the containers in 'detached' mode so that they run in the background.
+	- The content-web app expects an environment variable named `CONTENT_API_URL` that points to the API app's URL.
 	- **NOTE:** The containers need to run in the same network to talk to each other. 
 		- Create a Docker network named "fabmedical"
 		- Run each container using the "fabmedical" network
 		- **Hint:** Each container you run needs to have a "name" on the fabmedical network and this is how you access it from other containers on that network.
 		- **Hint:** You can run your containers in "detached" mode so that the running container does NOT block your command prompt.
 
-## Success Criteria
 
-1. You can run both the web and api parts of the FabMedical app locally on your machine
-1. You have created 2 Dockerfiles files and created a container image for both web and api.
-1. You can run the application locally from the containers just built.
 
 ## Learning Resources
 
-Reference articles on how to Dockerize a Node.js app:
-- <https://nodejs.org/en/docs/guides/nodejs-docker-webapp/>
-- <https://buddy.works/guides/how-dockerize-node-application>
-- <https://www.cuelogic.com/blog/why-and-how-to-containerize-modern-nodejs-applications>
+See Docker documentation:  https://docs.docker.com/get-started/07_multi_container/


### PR DESCRIPTION
Made edits to IntrotoKubernetes Ch01 Containers:
- Clarified flow & explanation about using either the student's own workstation, or using a linux build server
- Removed requirement for students to run the app locally; instead I suggest that the coach demo this.  Reasoning:  this is a kubernetes hack, not a dev hack.
- **Significant edit:**  I provide the Dockerfiles to the students, removing the requirement for them to create their own.  My reasoning is 1) this is a kubernetes hack, not a containers hack, and 2) based on my experience coaching similar hacks, such a task could consume significant time and take away from time spent on kubernetes topics.
- I also add a warning in the coach notes to timebox this challenge.  Again, based on my experience, students can get stuck on this challenge and consume too much time on it.