### PR TITLE
Changed baseUri property

### DIFF
--- a/038-MDWCovid19/Coach/LabDeployment/deploy/ARM/azuredeploy.parameters.json
+++ b/038-MDWCovid19/Coach/LabDeployment/deploy/ARM/azuredeploy.parameters.json
@@ -21,7 +21,7 @@
       "value": ""
     },
     "covid19BaseUri": {
-      "value": "https://raw.githubusercontent.com/chrisbaudo/covid19wth/main/"
+      "value": "https://raw.githubusercontent.com/microsoft/WhatTheHack/master/038-MDWCovid19/Coach/LabDeployment/"
     },
     "covid19DacPacFileName": {
       "value": "covid19.bacpac"


### PR DESCRIPTION
I changed the baseUri property to use the ARM templates, scripts, database backups, etc. from the recently-committed WhatTheHack for COVID19.  This will allow me to delete my personal COVID19 repo in the future.