### PR TITLE
Enhancements to 021 identity for apps

### DIFF
--- a/021-IdentityForApps/Student/02-susi.md
+++ b/021-IdentityForApps/Student/02-susi.md
@@ -24,7 +24,7 @@ They are asking that you collect the following attributes of each consultant:
 
 It should be noted that CMC only is licensed to do business in the following states: **New York (NY), Ohio (OH) and Pennsylvania (PA)** (values between parentheses represent the values that should be stored in the directory).
 
-CMC IT Management has also asked that First and Last Name are displayed BEFORE Display Name on the sign up form. There's also a rumor that IT Management has also expressed that they are partial to the Slate Gray User Flow template.
+CMC IT Management has also asked that First and Last Name are displayed BEFORE Display Name on the sign up form. There's also a rumor that IT Management really likes the Slate Gray User Flow template.
 
 CMC IT Management also wants the same attributes returned when the user successfully logs in, along with the Identity Provider name.
 ## Success Criteria

--- a/021-IdentityForApps/Student/02-susi.md
+++ b/021-IdentityForApps/Student/02-susi.md
@@ -22,7 +22,7 @@ They are asking that you collect the following attributes of each consultant:
 - State
 - CMC Consultant ID (named "ConsultantID")
 
-It should be noted that CMC only is licensed to do business in the following states: **NY, PA, OH, IN, IL, MN, WI, KY, WV, IA, MI**.
+It should be noted that CMC only is licensed to do business in the following states: **New York (NY), Ohio (OH) and Pennsylvania (PA)** (values between parentheses represent the values that should be stored in the directory).
 
 CMC IT Management has also asked that First and Last Name are displayed BEFORE Display Name on the sign up form. There's also a rumor that IT Management has also expressed that they are partial to the Slate Gray User Flow template.
 

--- a/021-IdentityForApps/Student/04-l14n.md
+++ b/021-IdentityForApps/Student/04-l14n.md
@@ -63,6 +63,10 @@ CMC IT Leadership will consider this step successfully completed if you have:
 
 - To deploy the Harness Application, you can deploy it easily using VS Code's [Azure App Service extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureappservice), or via Visual Studio. If you use the App Service extension for VS Code, you can allow the extension to create an app service for you and then you can browse to the website when the deployment is complete.
 
+- Alternative, to get the site up and running quickly this can also be done in a single Azure CLI command as follows:
+
+    `az webapp up -n [name-of-webapp-to-create] -g [name-of-resource-group] -p [name-of-appsvc-plan] -l [location] --runtime "DOTNETCORE|3.1"`
+
 ## Learning Resources
 
 - [Customizing Azure AD B2C UX](https://docs.microsoft.com/en-us/azure/active-directory-b2c/customize-ui-overview#custom-html-and-css)

--- a/021-IdentityForApps/Student/04-l14n.md
+++ b/021-IdentityForApps/Student/04-l14n.md
@@ -57,6 +57,10 @@ CMC IT Leadership will consider this step successfully completed if you have:
 
 - For the custom templates, there is a placeholder for a storage account name. There are four files that have a number of "<your-storage-account-name>" markers. Do a global search-and-replace on that marker with your actual storage account name before you upload the files to your storage account.
 
+- In order to upload many files to storage at once, this is a convenient Azure CLI command one might want to use:
+
+    `az storage blob upload-batch -d [container-name] --account-name [storage-acct-name] -s .`
+
 - To deploy the Harness Application, you can deploy it easily using VS Code's [Azure App Service extension](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azureappservice), or via Visual Studio. If you use the App Service extension for VS Code, you can allow the extension to create an app service for you and then you can browse to the website when the deployment is complete.
 
 ## Learning Resources

--- a/021-IdentityForApps/Student/Resources/HarnessApp/.devcontainer/Dockerfile
+++ b/021-IdentityForApps/Student/Resources/HarnessApp/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet/.devcontainer/base.Dockerfile
+
+# [Choice] .NET version: 5.0, 3.1, 2.1
+ARG VARIANT="5.0"
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
+
+# [Option] Install Node.js
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Option] Install Azure CLI
+ARG INSTALL_AZURE_CLI="false"
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
+RUN if [ "$INSTALL_AZURE_CLI" = "true" ]; then bash /tmp/library-scripts/azcli-debian.sh; fi \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/021-IdentityForApps/Student/Resources/HarnessApp/.devcontainer/devcontainer.json
+++ b/021-IdentityForApps/Student/Resources/HarnessApp/.devcontainer/devcontainer.json
@@ -1,0 +1,58 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet
+{
+	"name": "C# (.NET)",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": { 
+			// Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
+			"VARIANT": "3.1",
+			// Options
+			"INSTALL_NODE": "true",
+			"NODE_VERSION": "lts/*",
+			"INSTALL_AZURE_CLI": "true"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-dotnettools.csharp"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [5000, 5001],
+
+	// [Optional] To reuse of your local HTTPS dev cert:
+	//
+	// 1. Export it locally using this command:
+	//    * Windows PowerShell:
+	//        dotnet dev-certs https --trust; dotnet dev-certs https -ep "$env:USERPROFILE/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+	//    * macOS/Linux terminal:
+	//        dotnet dev-certs https --trust; dotnet dev-certs https -ep "${HOME}/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+	// 
+	// 2. Uncomment these 'remoteEnv' lines:
+	//    "remoteEnv": {
+	// 	      "ASPNETCORE_Kestrel__Certificates__Default__Password": "SecurePwdGoesHere",
+	//        "ASPNETCORE_Kestrel__Certificates__Default__Path": "/home/vscode/.aspnet/https/aspnetapp.pfx",
+	//    },
+	//
+	// 3. Do one of the following depending on your scenario:
+	//    * When using GitHub Codespaces and/or Remote - Containers:
+	//      1. Start the container
+	//      2. Drag ~/.aspnet/https/aspnetapp.pfx into the root of the file explorer
+	//      3. Open a terminal in VS Code and run "mkdir -p /home/vscode/.aspnet/https && mv aspnetapp.pfx /home/vscode/.aspnet/https"
+	//
+	//    * If only using Remote - Containers with a local container, uncomment this line instead:
+	//      "mounts": [ "source=${env:HOME}${env:USERPROFILE}/.aspnet/https,target=/home/vscode/.aspnet/https,type=bind" ],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "dotnet restore",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/021-IdentityForApps/Student/Resources/HarnessApp/.devcontainer/library-scripts/azcli-debian.sh
+++ b/021-IdentityForApps/Student/Resources/HarnessApp/.devcontainer/library-scripts/azcli-debian.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/azcli.md
+# Maintainer: The VS Code and Codespaces Teams
+#
+# Syntax: ./azcli-debian.sh
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install curl, apt-transport-https, lsb-release, or gpg if missing
+if ! dpkg -s apt-transport-https curl ca-certificates lsb-release > /dev/null 2>&1 || ! type gpg > /dev/null 2>&1; then
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        apt-get update
+    fi
+    apt-get -y install --no-install-recommends apt-transport-https curl ca-certificates lsb-release gnupg2 
+fi
+
+# Install the Azure CLI
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list
+curl -sL https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+apt-get update
+apt-get install -y azure-cli
+echo "Done!"

--- a/021-IdentityForApps/Student/Resources/MSGraphApp/.devcontainer/Dockerfile
+++ b/021-IdentityForApps/Student/Resources/MSGraphApp/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet/.devcontainer/base.Dockerfile
+
+# [Choice] .NET version: 5.0, 3.1, 2.1
+ARG VARIANT="5.0"
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
+
+# [Option] Install Node.js
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Option] Install Azure CLI
+ARG INSTALL_AZURE_CLI="false"
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
+RUN if [ "$INSTALL_AZURE_CLI" = "true" ]; then bash /tmp/library-scripts/azcli-debian.sh; fi \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/021-IdentityForApps/Student/Resources/MSGraphApp/.devcontainer/devcontainer.json
+++ b/021-IdentityForApps/Student/Resources/MSGraphApp/.devcontainer/devcontainer.json
@@ -1,0 +1,58 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet
+{
+	"name": "C# (.NET)",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": { 
+			// Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
+			"VARIANT": "3.1",
+			// Options
+			"INSTALL_NODE": "true",
+			"NODE_VERSION": "lts/*",
+			"INSTALL_AZURE_CLI": "true"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-dotnettools.csharp"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [5000, 5001],
+
+	// [Optional] To reuse of your local HTTPS dev cert:
+	//
+	// 1. Export it locally using this command:
+	//    * Windows PowerShell:
+	//        dotnet dev-certs https --trust; dotnet dev-certs https -ep "$env:USERPROFILE/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+	//    * macOS/Linux terminal:
+	//        dotnet dev-certs https --trust; dotnet dev-certs https -ep "${HOME}/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+	// 
+	// 2. Uncomment these 'remoteEnv' lines:
+	//    "remoteEnv": {
+	// 	      "ASPNETCORE_Kestrel__Certificates__Default__Password": "SecurePwdGoesHere",
+	//        "ASPNETCORE_Kestrel__Certificates__Default__Path": "/home/vscode/.aspnet/https/aspnetapp.pfx",
+	//    },
+	//
+	// 3. Do one of the following depending on your scenario:
+	//    * When using GitHub Codespaces and/or Remote - Containers:
+	//      1. Start the container
+	//      2. Drag ~/.aspnet/https/aspnetapp.pfx into the root of the file explorer
+	//      3. Open a terminal in VS Code and run "mkdir -p /home/vscode/.aspnet/https && mv aspnetapp.pfx /home/vscode/.aspnet/https"
+	//
+	//    * If only using Remote - Containers with a local container, uncomment this line instead:
+	//      "mounts": [ "source=${env:HOME}${env:USERPROFILE}/.aspnet/https,target=/home/vscode/.aspnet/https,type=bind" ],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "dotnet restore",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/021-IdentityForApps/Student/Resources/MSGraphApp/.devcontainer/library-scripts/azcli-debian.sh
+++ b/021-IdentityForApps/Student/Resources/MSGraphApp/.devcontainer/library-scripts/azcli-debian.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/azcli.md
+# Maintainer: The VS Code and Codespaces Teams
+#
+# Syntax: ./azcli-debian.sh
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install curl, apt-transport-https, lsb-release, or gpg if missing
+if ! dpkg -s apt-transport-https curl ca-certificates lsb-release > /dev/null 2>&1 || ! type gpg > /dev/null 2>&1; then
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        apt-get update
+    fi
+    apt-get -y install --no-install-recommends apt-transport-https curl ca-certificates lsb-release gnupg2 
+fi
+
+# Install the Azure CLI
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list
+curl -sL https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+apt-get update
+apt-get install -y azure-cli
+echo "Done!"

--- a/021-IdentityForApps/Student/Resources/MSGraphApp/src/Models/AppSettings.cs
+++ b/021-IdentityForApps/Student/Resources/MSGraphApp/src/Models/AppSettings.cs
@@ -41,5 +41,11 @@ namespace b2c_ms_graph
         [JsonProperty(PropertyName = "UsersFileName")]
         public string UsersFileName { get; set; }
 
+        [JsonProperty(PropertyName = "ConsultantIdCustomAttributeName")]
+        public string ConsultantIdCustomAttributeName { get; set; }
+
+        [JsonProperty(PropertyName = "TerritoryNameCustomAttributeName")]
+        public string TerritoryNameCustomAttributeName { get; set; }
+
     }
 }

--- a/021-IdentityForApps/Student/Resources/MSGraphApp/src/Services/UserService.cs
+++ b/021-IdentityForApps/Student/Resources/MSGraphApp/src/Services/UserService.cs
@@ -35,15 +35,16 @@ namespace b2c_ms_graph
 
         public static async Task ListUsersWithCustomAttribute(GraphServiceClient graphClient, string b2cExtensionAppClientId)
         {
+            AppSettings config = AppSettingsFile.ReadFromJsonFile();
+
             if (string.IsNullOrWhiteSpace(b2cExtensionAppClientId))
             {
                 throw new ArgumentException("B2cExtensionAppClientId (its Application ID) is missing from appsettings.json. Find it in the App registrations pane in the Azure portal. The app registration has the name 'b2c-extensions-app. Do not modify. Used by AADB2C for storing user data.'.", nameof(b2cExtensionAppClientId));
             }
 
             // Declare the names of the custom attributes
-            // TODO -- change the attribute names!!
-            const string customAttributeName1 = "<cmc-id-attribute-name>";
-            const string customAttributeName2 = "<territory-name-attribute-name>";
+            var customAttributeName1 =  config.ConsultantIdCustomAttributeName;
+            var customAttributeName2 = config.TerritoryNameCustomAttributeName;
 
             // Get the complete name of the custom attribute (Azure AD extension)
             Helpers.B2cCustomAttributeHelper helper = new Helpers.B2cCustomAttributeHelper(b2cExtensionAppClientId);

--- a/021-IdentityForApps/Student/Resources/MSGraphApp/src/appsettings.json
+++ b/021-IdentityForApps/Student/Resources/MSGraphApp/src/appsettings.json
@@ -4,6 +4,8 @@
     "AppId": "Application (client) ID",
     "ClientSecret": "Client secret",
     "B2cExtensionAppClientId": "Find this Application (client) ID in the App registrations pane in the Azure portal. The app registration is named 'b2c-extensions-app. Do not modify. Used by AADB2C for storing user data.'.",
-    "UsersFileName": "users.json"
+    "UsersFileName": "users.json",
+    "ConsultantIdCustomAttributeName": "ConsultantID",
+    "TerritoryNameCustomAttributeName": "TerritoryName"
   }
 }

--- a/021-IdentityForApps/Student/Resources/Verify-inator/.devcontainer/Dockerfile
+++ b/021-IdentityForApps/Student/Resources/Verify-inator/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet/.devcontainer/base.Dockerfile
+
+# [Choice] .NET version: 5.0, 3.1, 2.1
+ARG VARIANT="5.0"
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
+
+# [Option] Install Node.js
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# [Option] Install Azure CLI
+ARG INSTALL_AZURE_CLI="false"
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
+RUN if [ "$INSTALL_AZURE_CLI" = "true" ]; then bash /tmp/library-scripts/azcli-debian.sh; fi \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/021-IdentityForApps/Student/Resources/Verify-inator/.devcontainer/devcontainer.json
+++ b/021-IdentityForApps/Student/Resources/Verify-inator/.devcontainer/devcontainer.json
@@ -1,0 +1,59 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/dotnet
+{
+	"name": "C# (.NET)",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": { 
+			// Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
+			"VARIANT": "3.1",
+			// Options
+			"INSTALL_NODE": "true",
+			"NODE_VERSION": "lts/*",
+			"INSTALL_AZURE_CLI": "true"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-dotnettools.csharp",
+		"humao.rest-client"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [5000, 5001],
+
+	// [Optional] To reuse of your local HTTPS dev cert:
+	//
+	// 1. Export it locally using this command:
+	//    * Windows PowerShell:
+	//        dotnet dev-certs https --trust; dotnet dev-certs https -ep "$env:USERPROFILE/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+	//    * macOS/Linux terminal:
+	//        dotnet dev-certs https --trust; dotnet dev-certs https -ep "${HOME}/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+	// 
+	// 2. Uncomment these 'remoteEnv' lines:
+	//    "remoteEnv": {
+	// 	      "ASPNETCORE_Kestrel__Certificates__Default__Password": "SecurePwdGoesHere",
+	//        "ASPNETCORE_Kestrel__Certificates__Default__Path": "/home/vscode/.aspnet/https/aspnetapp.pfx",
+	//    },
+	//
+	// 3. Do one of the following depending on your scenario:
+	//    * When using GitHub Codespaces and/or Remote - Containers:
+	//      1. Start the container
+	//      2. Drag ~/.aspnet/https/aspnetapp.pfx into the root of the file explorer
+	//      3. Open a terminal in VS Code and run "mkdir -p /home/vscode/.aspnet/https && mv aspnetapp.pfx /home/vscode/.aspnet/https"
+	//
+	//    * If only using Remote - Containers with a local container, uncomment this line instead:
+	//      "mounts": [ "source=${env:HOME}${env:USERPROFILE}/.aspnet/https,target=/home/vscode/.aspnet/https,type=bind" ],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "dotnet restore",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/021-IdentityForApps/Student/Resources/Verify-inator/.devcontainer/library-scripts/azcli-debian.sh
+++ b/021-IdentityForApps/Student/Resources/Verify-inator/.devcontainer/library-scripts/azcli-debian.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/azcli.md
+# Maintainer: The VS Code and Codespaces Teams
+#
+# Syntax: ./azcli-debian.sh
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install curl, apt-transport-https, lsb-release, or gpg if missing
+if ! dpkg -s apt-transport-https curl ca-certificates lsb-release > /dev/null 2>&1 || ! type gpg > /dev/null 2>&1; then
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        apt-get update
+    fi
+    apt-get -y install --no-install-recommends apt-transport-https curl ca-certificates lsb-release gnupg2 
+fi
+
+# Install the Azure CLI
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list
+curl -sL https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+apt-get update
+apt-get install -y azure-cli
+echo "Done!"

--- a/021-IdentityForApps/Student/Resources/Verify-inator/tests.http
+++ b/021-IdentityForApps/Student/Resources/Verify-inator/tests.http
@@ -1,0 +1,15 @@
+@endpoint = https://[name-of-app-service].azurewebsites.net/Territory
+@b2cappid = [your-b2c-app-id]
+
+# Notes: no dashes in the b2c app id
+# THE BELOW SHOULD BE A VALID REQUEST TO TEST YOUR API CONNECTOR WITH
+POST {{endpoint}} HTTP/1.1
+content-type: application/json
+
+{
+    "givenName": "Dave",
+    "surname": "Lastname",
+    "extension_{{b2cappid}}_ConsultantID": "123ABCD456",
+    "state": "PA",
+    "city": "Pittsburgh"
+}


### PR DESCRIPTION
- added azure cli command to quickly upload blobs in batch so attendees don't lose time on this
- added azure cli command to quickly spin up the harness app in app service so attendees don't lose time on this
- added devcontainers with .NET 3.1 and Azure CLI for:
  - harness app
  - management app (using graph api to query b2c)
  - verify-inator api connector app (contains rest client extension in addition to .net and azure cli)
- added valid http test file for testing api connector with
- make custom user attributes configurable in appsettings.json for MSGraphApp