### PR TITLE
IntrotoAKS: change year to 2021 in content-web v2

### DIFF
--- a/001-IntroToKubernetes/Student/Resources/Challenge 7/content-web-v2/public/index.html
+++ b/001-IntroToKubernetes/Student/Resources/Challenge 7/content-web-v2/public/index.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8"/>
-  <title>Contoso Neuro 2019 Conference </title>
+  <title>Contoso Neuro 2021 Conference </title>
   <link rel="image_src" type="image/gif" href="https://techintersection.com/images/Contoso Neuro 2016_2015_banner.gif"/>
 
   <link rel="stylesheet" href="stylesheets/font-awesome.min.css"/>
@@ -24,7 +24,7 @@
       <nav id="top-bar" data-topbar class="top-bar" role="navigation" data-options="sticky_on: small-up">
         <ul class="title-area">
           <li class="name">
-            <h1 class="contosoevents"><a href="/">Contoso Neuro 2019 Conference</a></h1>
+            <h1 class="contosoevents"><a href="/">Contoso Neuro 2021 Conference</a></h1>
           </li>
           <li class="toggle-topbar menu-icon"><a href="#"><span>Menu</span></a></li>
         </ul>
@@ -42,7 +42,7 @@
     </div>
     <div class="hero large-4 hero-panel">
     <div class="row">
-      <h1>FEBRUARY <span class="highlight">14-17,</span> 2019</h1>
+      <h1>FEBRUARY <span class="highlight">14-17,</span> 2021</h1>
       <p>Monterey Conference Center<p>
       <p>Monterey, California<p>
       <!--<p style="font-size: 40px; color: #fff; text-shadow: -1px 1px 2px rgba(150, 150, 150, 1); padding: 120px;">October 22-28<br>at Super Fancy Hotel</p>-->
@@ -62,7 +62,7 @@
       <div class="row">
         <div class="small-12 columns">
           <ul style="margin-bottom: 0;">
-            <li>Copyright &copy; 2019 Contoso Neuro. All rights reserved.</li>
+            <li>Copyright &copy; 2021 Contoso Neuro. All rights reserved.</li>
           </ul>
         </div>
       </div>

--- a/001-IntroToKubernetes/Student/Resources/Challenge 7/content-web-v2/public/index.html
+++ b/001-IntroToKubernetes/Student/Resources/Challenge 7/content-web-v2/public/index.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8"/>
-  <title>Contoso Neuro 2020 Conference </title>
+  <title>Contoso Neuro 2019 Conference </title>
   <link rel="image_src" type="image/gif" href="https://techintersection.com/images/Contoso Neuro 2016_2015_banner.gif"/>
 
   <link rel="stylesheet" href="stylesheets/font-awesome.min.css"/>
@@ -24,7 +24,7 @@
       <nav id="top-bar" data-topbar class="top-bar" role="navigation" data-options="sticky_on: small-up">
         <ul class="title-area">
           <li class="name">
-            <h1 class="contosoevents"><a href="/">Contoso Neuro 2020 Conference</a></h1>
+            <h1 class="contosoevents"><a href="/">Contoso Neuro 2019 Conference</a></h1>
           </li>
           <li class="toggle-topbar menu-icon"><a href="#"><span>Menu</span></a></li>
         </ul>
@@ -42,7 +42,7 @@
     </div>
     <div class="hero large-4 hero-panel">
     <div class="row">
-      <h1>FEBRUARY <span class="highlight">14-17,</span> 2020</h1>
+      <h1>FEBRUARY <span class="highlight">14-17,</span> 2019</h1>
       <p>Monterey Conference Center<p>
       <p>Monterey, California<p>
       <!--<p style="font-size: 40px; color: #fff; text-shadow: -1px 1px 2px rgba(150, 150, 150, 1); padding: 120px;">October 22-28<br>at Super Fancy Hotel</p>-->
@@ -62,7 +62,7 @@
       <div class="row">
         <div class="small-12 columns">
           <ul style="margin-bottom: 0;">
-            <li>Copyright &copy; 2020 Contoso Neuro. All rights reserved.</li>
+            <li>Copyright &copy; 2019 Contoso Neuro. All rights reserved.</li>
           </ul>
         </div>
       </div>

--- a/001-IntroToKubernetes/Student/Resources/Challenge 7/content-web-v2/public/sessions.html
+++ b/001-IntroToKubernetes/Student/Resources/Challenge 7/content-web-v2/public/sessions.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8"/>
- <title>Contoso Neuro 2019 Conference</title>
+ <title>Contoso Neuro 2021 Conference</title>
 
   <link rel="stylesheet" href="stylesheets/font-awesome.min.css">
   <link rel="stylesheet" href="stylesheets/app.css"/>
@@ -40,7 +40,7 @@
       <nav id="top-bar" data-topbar class="top-bar" role="navigation" data-options="sticky_on: small-up">
         <ul class="title-area">
           <li class="name">
-            <h1 class="contosoevents"><a href="/">Contoso Neuro 2019 Conference</a></h1>
+            <h1 class="contosoevents"><a href="/">Contoso Neuro 2021 Conference</a></h1>
           </li>
           <!-- Remove the class "menu-icon" to get rid of menu icon. Take out "Menu" to just have icon alone -->
           <li class="toggle-topbar menu-icon"><a href="#"><span>Menu</span></a></li>
@@ -60,7 +60,7 @@
 
     <div class="hero large-4 hero-panel">
       <div class="row">
-        <h1>FEBRUARY <span class="highlight">14-17,</span> 2019</h1>
+        <h1>FEBRUARY <span class="highlight">14-17,</span> 2021</h1>
         <p>Monterey Conference Center<p>
         <p>Monterey, California<p>
         <!--<p style="font-size: 40px; color: #fff; text-shadow: -1px 1px 2px rgba(150, 150, 150, 1); padding: 120px;">October 22-28<br>at Super Fancy Hotel</p>-->
@@ -95,7 +95,7 @@
     <div class="row">
       <div class="small-12 columns">
         <ul style="margin-bottom: 0;">
-          <li>Copyright &copy; 2019 Contoso Neuro. All rights reserved.</li>
+          <li>Copyright &copy; 2021 Contoso Neuro. All rights reserved.</li>
         </ul>
       </div>
     </div>

--- a/001-IntroToKubernetes/Student/Resources/Challenge 7/content-web-v2/public/speakers.html
+++ b/001-IntroToKubernetes/Student/Resources/Challenge 7/content-web-v2/public/speakers.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Contoso Neuro 2019 Conference</title>
+  <title>Contoso Neuro 2021 Conference</title>
   <link rel="stylesheet" href="stylesheets/font-awesome.min.css">
   <link rel="stylesheet" href="stylesheets/app.css"/>
     <script src="bower_components/modernizr/modernizr.js"></script>
@@ -39,7 +39,7 @@
       <nav id="top-bar" data-topbar class="top-bar" role="navigation" data-options="sticky_on: small-up">
         <ul class="title-area">
           <li class="name">
-            <h1 class="contosoevents"><a href="/">Contoso Neuro 2019 Conference</a></h1>
+            <h1 class="contosoevents"><a href="/">Contoso Neuro 2021 Conference</a></h1>
           </li>
           <!-- Remove the class "menu-icon" to get rid of menu icon. Take out "Menu" to just have icon alone -->
           <li class="toggle-topbar menu-icon"><a href="#"><span>Menu</span></a></li>
@@ -58,7 +58,7 @@
     </div>
     <div class="hero large-4 hero-panel">
       <div class="row">
-        <h1>FEBRUARY <span class="highlight">14-17,</span> 2019</h1>
+        <h1>FEBRUARY <span class="highlight">14-17,</span> 2021</h1>
         <p>Monterey Conference Center<p>
         <p>Monterey, California<p>
         <!--<p style="font-size: 40px; color: #fff; text-shadow: -1px 1px 2px rgba(150, 150, 150, 1); padding: 120px;">October 22-28<br>at Super Fancy Hotel</p>-->
@@ -101,7 +101,7 @@
         <div class="small-12 columns">
 
           <ul style="margin-bottom: 0;">
-            <li>Copyright &copy; 2019 Contoso Neuro. All rights reserved. </li>
+            <li>Copyright &copy; 2021 Contoso Neuro. All rights reserved. </li>
           </ul>
         </div>
       </div>

--- a/001-IntroToKubernetes/Student/Resources/Challenge 7/content-web-v2/public/stats.html
+++ b/001-IntroToKubernetes/Student/Resources/Challenge 7/content-web-v2/public/stats.html
@@ -2,7 +2,7 @@
 <html class="no-js" lang="en">
 <head>
   <meta charset="utf-8"/>
-  <title>Contoso Neuro 2019 Conference</title>
+  <title>Contoso Neuro 2021 Conference</title>
 
   <link rel="stylesheet" href="stylesheets/font-awesome.min.css">
   <link rel="stylesheet" href="stylesheets/app.css"/>
@@ -39,7 +39,7 @@
       <nav id="top-bar" data-topbar class="top-bar" role="navigation" data-options="sticky_on: small-up">
         <ul class="title-area">
           <li class="name">
-            <h1 class="contosoevents"><a href="/">Contoso Neuro 2019 Conference</a></h1>
+            <h1 class="contosoevents"><a href="/">Contoso Neuro 2021 Conference</a></h1>
           </li>
           <!-- Remove the class "menu-icon" to get rid of menu icon. Take out "Menu" to just have icon alone -->
           <li class="toggle-topbar menu-icon"><a href="#"><span>Menu</span></a></li>
@@ -127,7 +127,7 @@
     <div class="row">
       <div class="small-12 columns">
         <ul style="margin-bottom: 0;">
-          <li>Copyright &copy; 2019 Contoso Neuro. All rights reserved. </li>
+          <li>Copyright &copy; 2021 Contoso Neuro. All rights reserved. </li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Fixes #202 :   With V2 of the app, when you are on the home page, it shows the date: 'FEBRUARY 14-17, 2020', but when you go to /sessions or /speakers, it shows the date 'FEBRUARY 14-17, 2019'.

Made a simple correction to the the file \Student\Resources\Challenge 7\content-web-v2\public\index.html


**NOTE:  Content owners will need to rebuild the docker image stored on dockerhub for this change to propagate out to endusers.** 