### PR TITLE
Intro-to-AKS: Automate building container images

### DIFF
--- a/.github/workflows/001IntroAKS-BuildDockerImages.yml
+++ b/.github/workflows/001IntroAKS-BuildDockerImages.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -30,11 +32,11 @@ jobs:
         uses: docker/build-push-action@v2
         id: contentwebv1
         with:
-          push: false
+          push: true
           # Build's context is the set of files located in the specified PATH or URL
           context: '001-IntroToKubernetes/Student/Resources/Challenge 1/content-web'
           # Path to the Dockerfile
           file: '001-IntroToKubernetes/Coach/Solutions/Challenge 1/content-web/Dockerfile-solution'
           # List of tags
-          tags: ${REGISTRY}/${CONTENTWEBTAG}:v1, ${REGISTRY}/${CONTENTWEBTAG}:latest
+          tags: ${{ env.REGISTRY }}/${{env.CONTENTWEBTAG}}:v1, ${{ env.REGISTRY }}/${{env.CONTENTWEBTAG}}:latest
           #github-token: # optional, default is ${{ github.token }}

--- a/.github/workflows/001IntroAKS-BuildDockerImages.yml
+++ b/.github/workflows/001IntroAKS-BuildDockerImages.yml
@@ -1,0 +1,40 @@
+name: Build and Push IntrotoAKS Images
+on:
+  # push:
+  #   branches: [ master ]
+  # pull_request:
+  #   branches: [ master ]
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      CONTENTWEBTAG: larryclaman/content-web
+      CONTENTAPITAG: larryclaman/content-api
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push content-web v1
+        uses: docker/build-push-action@v2
+        id: contentwebv1
+        with:
+          push: false
+          # Build's context is the set of files located in the specified PATH or URL
+          context: '001-IntroToKubernetes/Student/Resources/Challenge 1/content-web'
+          # Path to the Dockerfile
+          file: '001-IntroToKubernetes/Coach/Solutions/Challenge 1/content-web/Dockerfile-solution'
+          # List of tags
+          tags: ${REGISTRY}/${CONTENTWEBTAG}:v1, ${REGISTRY}/${CONTENTWEBTAG}:latest
+          #github-token: # optional, default is ${{ github.token }}

--- a/.github/workflows/001IntroAKS-BuildDockerImages.yml
+++ b/.github/workflows/001IntroAKS-BuildDockerImages.yml
@@ -12,6 +12,7 @@ jobs:
       REGISTRY: ghcr.io
       CONTENTWEBTAG: larryclaman/content-web
       CONTENTAPITAG: larryclaman/content-api
+      CONTENTINITTAG: larryclaman/content-init
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
@@ -39,4 +40,56 @@ jobs:
           file: '001-IntroToKubernetes/Coach/Solutions/Challenge 1/content-web/Dockerfile-solution'
           # List of tags
           tags: ${{ env.REGISTRY }}/${{env.CONTENTWEBTAG}}:v1, ${{ env.REGISTRY }}/${{env.CONTENTWEBTAG}}:latest
+          #github-token: # optional, default is ${{ github.token }}
+
+      - name: Build and push content-api v1
+        uses: docker/build-push-action@v2
+        id: contentapiv1
+        with:
+          push: true
+          # Build's context is the set of files located in the specified PATH or URL
+          context: '001-IntroToKubernetes/Student/Resources/Challenge 1/content-api'
+          # Path to the Dockerfile
+          file: '001-IntroToKubernetes/Coach/Solutions/Challenge 1/content-api/Dockerfile-solution'
+          # List of tags
+          tags: ${{ env.REGISTRY }}/${{env.CONTENTAPITAG}}:v1, ${{ env.REGISTRY }}/${{env.CONTENTAPITAG}}:latest
+          #github-token: # optional, default is ${{ github.token }}
+
+      - name: Build and push content-web v2
+        uses: docker/build-push-action@v2
+        id: contentwebv2
+        with:
+          push: true
+          # Build's context is the set of files located in the specified PATH or URL
+          context: '001-IntroToKubernetes/Student/Resources/Challenge 7/content-web-v2'
+          # Path to the Dockerfile
+          file: '001-IntroToKubernetes/Student/Resources/Challenge 7/content-web-v2/Dockerfile'
+          # List of tags
+          tags: ${{ env.REGISTRY }}/${{env.CONTENTWEBTAG}}:v2
+          #github-token: # optional, default is ${{ github.token }}
+
+      - name: Build and push content-api v2
+        uses: docker/build-push-action@v2
+        id: contentapiv2
+        with:
+          push: true
+          # Build's context is the set of files located in the specified PATH or URL
+          context: '001-IntroToKubernetes/Student/Resources/Challenge 7/content-api-v2'
+          # Path to the Dockerfile
+          file: '001-IntroToKubernetes/Student/Resources/Challenge 7/content-api-v2/Dockerfile'
+          # List of tags
+          tags: ${{ env.REGISTRY }}/${{env.CONTENTAPITAG}}:v2
+          #github-token: # optional, default is ${{ github.token }}
+
+      - name: Build and push content-init
+        uses: docker/build-push-action@v2
+        id: contentinit
+        with:
+          push: true
+          # Build's context is the set of files located in the specified PATH or URL
+          context: '001-IntroToKubernetes/Student/Resources/Challenge 7/content-init'
+          # Path to the Dockerfile
+          file: '001-IntroToKubernetes/Student/Resources/Challenge 7/content-init/Dockerfile'
+          # List of tags
+          tags: ${{ env.REGISTRY }}/${{env.CONTENTINITTAG}}:latest
           #github-token: # optional, default is ${{ github.token }}


### PR DESCRIPTION
This pr introduces a github actions workflow that will help automate (re)building container images for use by the IntroToAKS hack.
The PR was inspired by issue #202  and PR #280.

As currently implemented, the action will only run manually (using workflow_dispatch), but if desired it could be improved to automatically rebuild images if new code is checked in.

**The repo owners will need to customize some of the variables used by this workflow; specifically the repo locations on dockerhub (which could be migrated to github if desired)**