### PR TITLE
IntrotoAKS: Quick fix to broken kibana link

### DIFF
--- a/001-IntroToKubernetes/Student/11-opsmonitoring.md
+++ b/001-IntroToKubernetes/Student/11-opsmonitoring.md
@@ -39,6 +39,6 @@ In this challenge you will learn how to view application logs and trouble-shoot 
     - <https://docs.microsoft.com/en-us/azure/azure-monitor/insights/container-insights-overview>
 - ELK stack:
     - <https://logz.io/learn/complete-guide-elk-stack>
-	- <https://kubernetes.io/docs/tasks/debug-application-cluster/logging-elasticsearch-kibana>
+	- <https://v1-19.docs.kubernetes.io/docs/tasks/debug-application-cluster/logging-elasticsearch-kibana/>
 - Fluentd:
     - <https://docs.fluentd.org>


### PR DESCRIPTION
Link to kibana info is broken.  This is a quick fix to that broken link.
Repo owners should feel free to replace with a link to a different documentation page.