### PR TITLE
Added `dapr init` to local exec in Solution-02.md

### DIFF
--- a/047-TrafficControlWithDapr/Coach/Solution-02.md
+++ b/047-TrafficControlWithDapr/Coach/Solution-02.md
@@ -26,6 +26,12 @@ You will use the Dapr CLI `run` command and specify all the options above on the
 
 1.  Make sure you have started Docker Desktop on your machine and the Dapr CLI and runtime are installed (see the [prerequisites](../README.md#prerequisites)).
 
+    If you haven't done so yet, you should now initialize Dapr on your local machine, too (here we won't be using your AKS cluster yet):
+
+    ``` shell
+    dapr init
+    ```
+
 2.  Open the `Resources` folder in this repo in VS Code.
 
 3.  Open the [terminal window](https://code.visualstudio.com/docs/editor/integrated-terminal) in VS Code and make sure the current folder is `Resources/VehicleRegistrationService`.


### PR DESCRIPTION
While the pre-reqs section links the correct (local) setup for Dapr, Challange 0 asks participants to run `dapr init -k`.
In Challange 2, we run Dapr locally, hence first it needs to be initialized via `dapr init`.