### PR TITLE
Create Code Owners File

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*      @whatthehack-admins
+
+# directory in the root of your repository and any of its
+# subdirectories.
+/000-HowToHack/ @jrzyshr
+/007-AzureMonitoring/ @shbabylo
+/047-TrafficControlWithDapr/ @jordanbean-msft


### PR DESCRIPTION
Allows for sub-management of individual hacks to allow for hack team approval before WTH v-team approval.