### PR TITLE
removing instructions to create sql server

### DIFF
--- a/019-ThisOldDataWarehouse/Student/Challenges/Challenge0/readme.md
+++ b/019-ThisOldDataWarehouse/Student/Challenges/Challenge0/readme.md
@@ -49,16 +49,9 @@ az account show
 az group create --location eastus2 --name {"Resource Group Name"}
 ```
 
-4. In the Cloudshell, run this command to create a SQL Server instance and restore the databases.  This will create an Azure Container Instance and restore the WideWorldImporters and WideWorldImoprtersDW databases.  These two databases are your LOB databases for this hack.
+4. Ask your coach for the hostname, username and password for your team. Then verify you can connect to the SQL Server and access two databases, WideWorldImporters and WideWorldImoprtersDW databases.  These two databases are your LOB databases for this hack.
 
-```
-az container create -g {Resource Group Name} --name mdwhackdb --image alexk002/sqlserver2019_demo:1  --cpu 2 --memory 7
---ports 1433 --ip-address Public
-```
-
-5. At the start of Challenge 1, reach out to your coach and they will share hostname, username and password for your team.
-
-6. [Upload](https://docs.microsoft.com/en-us/azure/cloud-shell/persisting-shell-storage#upload-files) your ARM templates into Azure CloudShell. 
+5. [Upload](https://docs.microsoft.com/en-us/azure/cloud-shell/persisting-shell-storage#upload-files) your ARM templates into Azure CloudShell. 
 
 
     /Student/Challenges/Challenge0/ARM.  
@@ -66,20 +59,20 @@ az container create -g {Resource Group Name} --name mdwhackdb --image alexk002/s
     Edit the parmeters file and replace any {} with information requested.  
 
 
-7. Run the last command to setup Azure Data Factory, SSIS Runtime, Vnet, and Azure SQL Database to host the SSIS catalog.  This will build out for Challenge one the SSIS environment in Azure Data Factory.
+6. Run the last command to setup Azure Data Factory, SSIS Runtime, Vnet, and Azure SQL Database to host the SSIS catalog.  This will build out for Challenge one the SSIS environment in Azure Data Factory.
 
 ```
 az deployment group create --name final --resource-group {ENTER RESOURCE GROUP NAME} --template-file template.json
 --parameters parametersFile.json
 ```
 
-8. Last step and most important start your Azure Data Factory SSIS Runtime Service.  Go to [Connection pane](https://docs.microsoft.com/en-us/azure/data-factory/tutorial-deploy-ssis-packages-azure#connections-pane) in your Azure Data Factory service.  Run before the kickoff presentation so it has enough time to start up before you start Challenge 1.  The startup time is approximately 30 minutes.
+7. Last step and most important start your Azure Data Factory SSIS Runtime Service.  Go to [Connection pane](https://docs.microsoft.com/en-us/azure/data-factory/tutorial-deploy-ssis-packages-azure#connections-pane) in your Azure Data Factory service.  Run before the kickoff presentation so it has enough time to start up before you start Challenge 1.  The startup time is approximately 30 minutes.
 
 
-10. Review the database catalog on the data warehouse for familiarity of the schema [Reference document](https://docs.microsoft.com/en-us/sql/samples/wide-world-importers-dw-database-catalog?view=sql-server-ver15)
+8. Review the database catalog on the data warehouse for familiarity of the schema [Reference document](https://docs.microsoft.com/en-us/sql/samples/wide-world-importers-dw-database-catalog?view=sql-server-ver15)
 
 
-11. Review ETL workflow to understand the data flow and architecture [Reference document](https://docs.microsoft.com/en-us/sql/samples/wide-world-importers-perform-etl?view=sql-server-ver15)
+9. Review ETL workflow to understand the data flow and architecture [Reference document](https://docs.microsoft.com/en-us/sql/samples/wide-world-importers-perform-etl?view=sql-server-ver15)
 
 
 ## On-premise Architecture


### PR DESCRIPTION
students don't need to create the container image and restore databases. the coach should do this once per team and then provide the details to the students in the team.