### PR TITLE
fixed README & template files

### DIFF
--- a/.github/workflows/create-wth-template.sh
+++ b/.github/workflows/create-wth-template.sh
@@ -105,6 +105,7 @@ GenerateNavitationLink() {
   local -r suffixNumber=$1
   local -r numberOfChallenges=$2
   local -r linkName=$3
+  local -r isCoachGuide=$4
 
   local navigationLine=""
 
@@ -126,7 +127,17 @@ GenerateNavitationLink() {
     nextNavigationLink=" - [Next $linkName >](./$linkName-$nextChallengeNumber.md)"
   fi
 
-  local -r navigationLine="$previousNavigationLink**[Home](../README.md)**$nextNavigationLink"
+  local homeLinkPath=""
+  
+  #if the navigation link is for Coach guides, it should point to the Coach/README, not the root README file
+  if $isCoachGuide
+  then
+    homeLinkPath="."
+  else  
+    homeLinkPath=".."
+  fi
+
+  local -r navigationLine="$previousNavigationLink**[Home]($homeLinkPath/README.md)**$nextNavigationLink"
 
   echo $navigationLine
 }
@@ -141,7 +152,7 @@ CreateChallengeMarkdownFile() {
     echo "Creating $fullPath/$prefix-$suffixNumber.md..."
   fi
 
-  local -r navigationLine=$(GenerateNavitationLink $suffixNumber $numberOfChallenges "Challenge")
+  local -r navigationLine=$(GenerateNavitationLink $suffixNumber $numberOfChallenges "Challenge" false)
 
   WriteMarkdownFile "$fullPath/$prefix-$suffixNumber.md" "WTH-Challenge-Template.md"
 }
@@ -155,7 +166,7 @@ CreateSolutionMarkdownFile() {
     echo "Creating $fullPath/$prefix-$suffixNumber.md..."
   fi
 
-  local -r navigationLine=$(GenerateNavitationLink $suffixNumber $numberOfChallenges "Solution")
+  local -r navigationLine=$(GenerateNavitationLink $suffixNumber $numberOfChallenges "Solution" true)
 
   WriteMarkdownFile "$fullPath/$prefix-$suffixNumber.md" "WTH-Challenge-Solution-Template.md"
 }

--- a/000-HowToHack/WTH-Challenge-Solution-Template.md
+++ b/000-HowToHack/WTH-Challenge-Solution-Template.md
@@ -1,4 +1,4 @@
-<!-- REMOVE_ME # Challenge ${suffixNumber} - Coach's Guide  (remove this from your MD files if you are writing them manually, this is for the automation script) REMOVE_ME -->
+<!-- REMOVE_ME # Challenge ${suffixNumber} - ${nameOfChallengeArg} - Coach's Guide  (remove this from your MD files if you are writing them manually, this is for the automation script) REMOVE_ME -->
 
 <!-- REPLACE_ME (this section will be removed by the automation script) -->
 # Challenge 01 - Coach's Guide
@@ -7,7 +7,7 @@
 <!-- REMOVE_ME ${navigationLine} (remove this from your MD files if you are writing them manually, this is for the automation script) REMOVE_ME -->
 
 <!-- REPLACE_ME (this section will be removed by the automation script) -->
-[< Previous Solution](./Solution-01.md) - **[Home](../README.md)** - [Next Solution >](./Solution-03.md)
+[< Previous Solution](./Solution-01.md) - **[Home](./README.md)** - [Next Solution >](./Solution-03.md)
 <!-- REPLACE_ME (this section will be removed by the automation script) -->
 
 ## Notes & Guidance

--- a/000-HowToHack/WTH-Challenge-Template.md
+++ b/000-HowToHack/WTH-Challenge-Template.md
@@ -1,4 +1,4 @@
-<!-- REMOVE_ME # Challenge ${suffixNumber} (remove this from your MD files if you are writing them manually, this is for the automation script) REMOVE_ME -->
+<!-- REMOVE_ME # Challenge ${suffixNumber} - ${nameOfChallengeArg} (remove this from your MD files if you are writing them manually, this is for the automation script) REMOVE_ME -->
 
 <!-- REPLACE_ME (this section will be removed by the automation script) -->
 # Challenge 01

--- a/000-HowToHack/WTH-CoachGuide-Template.md
+++ b/000-HowToHack/WTH-CoachGuide-Template.md
@@ -1,4 +1,4 @@
-<!-- REMOVE_ME # What The Hack - ${nameOfChallengeArg} Coach Guide (remove this from your MD files if you are writing them manually, this is for the automation script) REMOVE_ME -->
+<!-- REMOVE_ME # What The Hack - ${nameOfChallengeArg} - Coach Guide (remove this from your MD files if you are writing them manually, this is for the automation script) REMOVE_ME -->
 
 <!-- REPLACE_ME (this section will be removed by the automation script) -->
 # What The Hack - IoT Hack of the Century Coach Guide


### PR DESCRIPTION
This fixes the Coach guide Home links to point to the Coach/README file and adds the hack's title to the titles of the template files