### PR TITLE
Wth homepage update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+{% comment %} 
+# What The Hack - Repo
+
+Welcome to the What The Hack repo on GitHub. This repo contains Coach content designed for people planning to host a What The Hack event with students in an organization. 
+
+If you are attending a What The Hack event, or interested in sharing with an organization that wants to attend a What The Hack event, please visit our [What The Hack website](https://aka.ms/wth) at: https://aka.ms/wth 
+
+![What The Hack Website](/assets/images/wth-logo.png)
+{% endcomment %}
+
 # What is What The Hack?
 
 "What the Hack" is a set of challenge based hackathons that can be hosted in-person or virtually via Microsoft Teams.
@@ -112,5 +122,5 @@ Here is the current list of What The Hack hackathons available in this repositor
 - [Azure Virtual WAN](/041-VirtualWAN/README.md)
 - [Azure Front Door](/017-FrontDoor/README.md)
 
-# [License](https://github.com/Microsoft/WhatTheHack/blob/master/LICENSE)
+# License
 This repository is licensed under MIT license. More info can be found [here](https://github.com/Microsoft/WhatTheHack/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-{% comment %} 
+<!-- {% comment %} -->
 # What The Hack - Repo
 
 Welcome to the What The Hack repo on GitHub. This repo contains Coach content designed for people planning to host a What The Hack event with students in an organization. 
 
-If you are attending a What The Hack event, or interested in sharing with an organization that wants to attend a What The Hack event, please visit our [What The Hack website](https://aka.ms/wth) at: https://aka.ms/wth 
+If you are an organization that is interested in attending or hosting a What The Hack event, please visit the [What The Hack website](https://aka.ms/wth) at: **https://aka.ms/wth**
+
+**If you are a student attending a What The Hack event, please go to the [What The Hack website](https://aka.ms/wth)**
 
 ![What The Hack Website](/assets/images/wth-logo.png)
-{% endcomment %}
+<!-- {% endcomment %} -->
 
 # What is What The Hack?
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Welcome to the What The Hack repo on GitHub. This repo contains Coach content de
 
 If you are an organization that is interested in attending or hosting a What The Hack event, please visit the [What The Hack website](https://aka.ms/wth) at: **https://aka.ms/wth**
 
-**If you are a student attending a What The Hack event, please go to the [What The Hack website](https://aka.ms/wth)**
+**If you are a student attending a What The Hack event, please go to the [What The Hack website](https://aka.ms/wth).**
 
 ![What The Hack Website](/assets/images/wth-logo.png)
 <!-- {% endcomment %} -->


### PR DESCRIPTION
Added a link to the WTH website from the homepage of the WTH repo.  This link & message that re-directs students to the WTH Website is embedded in a "Liquid" comment to that Github Pages will not render it on the actual website itself.