### PR TITLE
[WTH Core] - chore: Auto update github actions with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Github Actions workflows use runners that are not up to date. Automatic updates can solve this and keep the project up to date in the future.

his PR adds a dependabot file to update the versions of the Github Actions used for CI jobs.
This requires to create a dependabot.yml file and to enable dependabot version updates in the settings of the repository

I applied this to my fork and it proposed the correct updates for the github actions.
https://github.com/iemejia/WhatTheHack/pulls