### PR TITLE
[Hack Update] 029-IoTEdge - 2022 Refresh

### DIFF
--- a/029-IoTEdge/Coach/Challenge-01.md
+++ b/029-IoTEdge/Coach/Challenge-01.md
@@ -9,6 +9,11 @@ Verify challengers have performed the following:
 1. IoT Hub created
 1. IoT Edge Device Endpoint created in the hub
 1. Ability to show what the device connection string is
-1. Provisioning a 'virtual' IoT Edge Device1. Participants should have IoT hub deployed and devices 
+1. Provisioning a 'virtual' IoT Edge Device1. Participants should have both IoT hub and devices deployed.  There are many ways to create an edge device on a virtual machine.  Review the following options to help guide students if needed.  
+    * [Run Azure IoT Edge on Ubuntu Virtual Machines](https://learn.microsoft.com/en-us/azure/iot-edge/how-to-install-iot-edge-ubuntuvm?view=iotedge-2018-06) 
+    * [Create and provision an IoT Edge device on Linux using symmetric keys](https://learn.microsoft.com/en-us/azure/iot-edge/how-to-provision-single-device-linux-symmetric?view=iotedge-1.4&tabs=azure-portal%2Cubuntu) 
+    * [Quickstart: Deploy your first IoT Edge module to a virtual Linux device](https://learn.microsoft.com/en-us/azure/iot-edge/quickstart-linux?view=iotedge-2018-06) 
+    * [Quickstart: Deploy your first IoT Edge module to a Windows device](https://learn.microsoft.com/en-us/azure/iot-edge/quickstart?view=iotedge-2018-06) 
+   
 
 

--- a/029-IoTEdge/Coach/Challenge-03.md
+++ b/029-IoTEdge/Coach/Challenge-03.md
@@ -32,13 +32,16 @@ For this module to be successful, participants must have the following tasks com
 
 + Details on the OPCPublisher module, command line options and configuration file format [look here](https://github.com/azure/iot-edge-opc-publisher)  This is important for participants to understand many OPC servers require authentication and tags may have different polling intervals/update requirements. 
 
-+ [Details on container create options](https://github.com/Azure/iot-edge-opc-publisher/blob/main/CommandLineArguments.md) for the OPCPublisher module
++ [Details on container create options](https://github.com/Azure/Industrial-IoT/blob/main/docs/modules/publisher-commandline.md) for the OPCPublisher module
     - Worth noting some parameters that can impact cost such as:
         -  --ms that highlights the size of messages to be sent to IoT hub.  making this 0 for instance will cause more data to be sent.  
         - --ih has to do with the protocol used to transmit data to IoT hub which is important to understand for participants to know what FW rules would be needed on the plant-floor.
         - --op highlights the publishing interval from OPC UA servers
         - --di controls the diagnostics logs emitted on the IoT Edge device 
         - --site controls the name of the site reported to IoT Hub
++ Considering that the OPC Publisher configuration isn't the most straight forward, students and coaches may use the following guides to help move forward if needed. 
+    - [Ingesting OPC UA data with Azure Digital Twins](https://learn.microsoft.com/en-us/azure/digital-twins/how-to-ingest-opcua-data)
+    - [Step-by-step guide to installing OPC Publisher on Azure IoT Edge](https://www.linkedin.com/pulse/step-by-step-guide-installing-opc-publisher-azure-iot-kevin-hilscher/)
 
 * * *  
 ### Configuring the OPC Publisher file
@@ -48,4 +51,4 @@ Important to note int the pn.json are the paths on the IoT edge that need to be 
 
 * * * 
 ## Advanced Challenges (Optional)
-It would also make sense to discuss the [Device Provisioning service](https://docs.microsoft.com/en-us/azure/iot-dps) and understand how this could be used to provision Edge devices in 'plants' around the globe using TPM or certificate based attestation.  While it's too challenging to perform these tasks as part of this lab; there are some paths that could be employed to provision a VM in Azure with a virtual TPM chip.  This would be a stretch assignment but something that could be explored with advanced teams.  [Details](https://docs.microsoft.com/en-us/azure/iot-dps/concepts-tpm-attestation)
+It would also make sense to discuss the [Device Provisioning service](https://docs.microsoft.com/en-us/azure/iot-dps) and understand how this could be used to provision Edge devices in 'plants' around the globe using TPM or certificate based attestation.  While it's too challenging to perform these tasks as part of this lab; there are some paths that could be employed to provision a VM in Azure with a virtual TPM chip.  This would be a stretch assignment but something that could be explored with advanced teams.  [TPM Attestation](https://docs.microsoft.com/en-us/azure/iot-dps/concepts-tpm-attestation)

--- a/029-IoTEdge/Coach/Challenge-07.md
+++ b/029-IoTEdge/Coach/Challenge-07.md
@@ -10,4 +10,4 @@ Remember that Device Streams are in **preview**.
 
 Additionally:
 
-- Block inbound SSH traffic (por 22) in your IoT Device. If you're running it in Azure, this can be done for example with a Network Security Group (NSG) attatched to the Vnet. Confirm the device is stil reachable.
+- Block inbound SSH traffic (port 22) in your IoT Device. If you're running it in Azure, this can be with a Network Security Group (NSG) attached to a VNet. Confirm the device is still reachable.

--- a/029-IoTEdge/README.md
+++ b/029-IoTEdge/README.md
@@ -73,3 +73,4 @@ In this hack you will solve common challenges for companies planning to use Azur
 - João Pedro Martins (@lokijota)
 - Orrin Edenfield
 - Amit Agrawal
+- Alan Kleinert

--- a/029-IoTEdge/Student/Challenge-01.md
+++ b/029-IoTEdge/Student/Challenge-01.md
@@ -45,7 +45,7 @@ Check for the updated list of supported regions here: [Device Streams: Regional 
 1. [Azure IoT Hub](https://docs.microsoft.com/en-us/azure/iot-hub/)
 1. [Azure IoT Edge](https://docs.microsoft.com/en-us/azure/iot-edge/about-iot-edge?view=iotedge-2018-06)
 1. [Azure Industrial IoT modules](https://azure.github.io/Industrial-IoT/)
-1. [IoT Edge Background Deck for WTH](../Coach/Presentations/IoTHub_Edge.pptx)
+1. [IoT Edge Background Deck for WTH](../Coach/Presentations/IoTHub_Edge.pptx?raw=true)
 
 
 ## Advanced Challenges (Optional)

--- a/029-IoTEdge/Student/Challenge-01.md
+++ b/029-IoTEdge/Student/Challenge-01.md
@@ -29,8 +29,7 @@ In this challenge you will establish all necessary cloud components needed to de
 
 Azure IoT Hub will be needed that is created in **one of the regions where Device Streams are available**. At the time of writing, these are: 
   - Central US
-  - Central US 
-  - EUAP (Early Updates Access Program)
+  - Central US EUAP (Early Updates Access Program)
   - North Europe
   - Southeast Asia. 
      
@@ -46,7 +45,7 @@ Check for the updated list of supported regions here: [Device Streams: Regional 
 1. [Azure IoT Hub](https://docs.microsoft.com/en-us/azure/iot-hub/)
 1. [Azure IoT Edge](https://docs.microsoft.com/en-us/azure/iot-edge/about-iot-edge?view=iotedge-2018-06)
 1. [Azure Industrial IoT modules](https://azure.github.io/Industrial-IoT/)
-1. [IoT Edge BackGround Deck for WTH](./assets/IoTHub_Edge.pptx)
+1. [IoT Edge Background Deck for WTH](../Coach/Presentations/IoTHub_Edge.pptx)
 
 
 ## Advanced Challenges (Optional)

--- a/029-IoTEdge/Student/Challenge-02.md
+++ b/029-IoTEdge/Student/Challenge-02.md
@@ -21,9 +21,8 @@ This challenge involves identifying software that would work to serve as a simul
 
 
 ## Tips
- - Options for OPC Simulators -- first 2 are VM-based options
+ - Options for OPC Simulators 
  1. [ProsysOPC UA Simulator](https://www.prosysopc.com/) -Free and supports many simulated endpoints
- 1. [Software ToolBox Top OPC Server](https://www.softwaretoolbox.com/) - Demo can run for 2 hours
  1. [Microsoft OPC PLC Simulator](https://github.com/Azure-Samples/iot-edge-opc-plc)  - Can be deployed as a container
  
 

--- a/029-IoTEdge/Student/Challenge-03.md
+++ b/029-IoTEdge/Student/Challenge-03.md
@@ -14,7 +14,7 @@ For this challenge you should focus on the steps below to successfully establish
 1. Configuration of IoT Edge Runtime to communicate with Azure HINT: This should be done in an automated fashion -- learning resources below.
 1. Configuration of OPC module(s) as per documentation HINT: This requires customization to the deployment/modules running on the Edge.
  + Documentation on OPC Publisher Module -- challenging to locate
-    - https://github.com/Azure/iot-edge-opc-publisher/blob/main/CommandLineArguments.md
+    - https://github.com/Azure/Industrial-IoT/blob/main/docs/modules/publisher-commandline.md
     - https://github.com/azure/iot-edge-opc-publisher
 
 

--- a/029-IoTEdge/Student/Challenge-05.md
+++ b/029-IoTEdge/Student/Challenge-05.md
@@ -18,7 +18,7 @@ In this challenge we'll be creating an Azure Stream Analytics job, using that jo
 1. In your Azure resource group create a Stream Analytics job.
 2. Set the input of the Stream Analytics job to be the route defined in your IoT Hub.
 3. Create 1 output to save a copy of all data into your data lake.
-4. Create a Query that filters or aggregates your data bases upon business requirements. Test this filter/aggregation (HAVING clause for example) but don't save in the query, only test.
+4. Create a Query that filters or aggregates your data based upon business requirements. Test this filter/aggregation (HAVING clause for example) but don't save in the query, only test.
 5. Test the query to ensure it is functioning as expected.
 6. Create a Power BI workspace (or identify an existing workspace for this workload).
 7. Create an additional output to the previously created/identified Power BI workspace.

--- a/029-IoTEdge/Student/Challenge-05.md
+++ b/029-IoTEdge/Student/Challenge-05.md
@@ -30,7 +30,7 @@ In this challenge we'll be creating an Azure Stream Analytics job, using that jo
   - Stream Analytics job setup & running with input reading data from `$upstream`
   - Stream Analytics job setup & running with output being written to Data Lake Store Gen2
   - Stream Analytics job filtering or aggregating data that is output
-  - Vizualizing the data in a Power BI report.
+  - Visualizing the data in a Power BI report.
 
 ## Learning Resources
 1. [Azure Stream Analytics Introduction](https://docs.microsoft.com/en-us/azure/stream-analytics/stream-analytics-introduction)

--- a/029-IoTEdge/Student/Challenge-06.md
+++ b/029-IoTEdge/Student/Challenge-06.md
@@ -26,7 +26,7 @@ High-level steps:
     - OPC Simulator module (from a previous challenge) and any required routes/configurations
     - Simulated Temperature Sensor module and any required routes
 
-1. Push the deployment manifest manifest to the IoT Hub, making sure that only the you target the tag you created in step 1, i.e., only the devices with that tag receive the deployment.
+1. Push the deployment manifest to the IoT Hub, making sure that you only target the tag you created in step 1, i.e., only the devices with that tag receive the deployment.
 
 1. Check the new IoT Edge device confirm that the modules running are the ones you specified in your deployment manifest.
 


### PR DESCRIPTION
	Changes
	Main Readme
	Added Alan Kleinert as Contributor

	Student Challenge 1
	Corrected Locations for Device Streams in Challenge 1 (Duplicate Central US to Central US EUAP (Early Updates Access Program)
	Fixed broken link for "IoT Edge BackGround Deck" and removed capitalization from the G in BackGround.

	Coach Challenge 1
	Added additional guidance and references to creating a "virtual" edge device

	Student Challenge 2
	Removed  "Software ToolBox Top OPC Server" from options for OPC as there are no coaches notes on it and the least favorable option out of the 3

	Student Challenge 3
	CommandLine link was broken so replaced it with active link

	Coach Challenge 3
	"Details on container create options" link was broken.  Replaced with new active link.
	Added two additional guides to help with OPC Publisher config if needed.
	Changed "Details" hyperlink to TPM Attestation

	Student Challenge 5
	Changed Vizualization to Visualization	
        Changed bases to based
	"Create a Query that filters or aggregates your data bases upon business requirements. Test this filter/aggregation (HAVING clause for example) but don't save in the query, only test."
     


	Student Challenge 6
	Removed duplicate of manifest, Switched the wording  to "you only target
	"Push the deployment manifest manifest to the IoT Hub, making sure that only the you target the tag you created in step 1, i.e., only the devices with that tag receive the deployment."
  
	Coach Challenge 7
	Corrected spelling and grammar 
	"Block inbound SSH traffic (port 22) in your IoT Device. If you're running it in Azure, this can be with a Network Security Group (NSG) attached to a VNet. Confirm the device is still reachable."
	

