### PR TITLE
[Hack Update] 056-CosmicTroubleshooting - Reduce number of engineInstances in load testing

### DIFF
--- a/056-CosmicTroubleshooting/Student/Resources/Challenge00/deploy.ps1
+++ b/056-CosmicTroubleshooting/Student/Resources/Challenge00/deploy.ps1
@@ -100,7 +100,7 @@ $createTestInvokeParams = @{
             keyvaultReferenceIdentityId   = $null;
             keyvaultReferenceIdentityType = "SystemAssigned";
             loadTestConfig                = @{
-                engineInstances = 4;
+                engineInstances = 1;
                 splitAllCSVs    = $FALSE;
             }
             passFailCriteria              = @{

--- a/056-CosmicTroubleshooting/Student/Resources/Challenge00/deploy.sh
+++ b/056-CosmicTroubleshooting/Student/Resources/Challenge00/deploy.sh
@@ -125,7 +125,7 @@ payload="{
     'keyvaultReferenceIdentityId': null,
     'keyvaultReferenceIdentityType': 'SystemAssigned',
     'loadTestConfig': {
-        'engineInstances': 4,
+        'engineInstances': 1,
         'splitAllCSVs': false
     },
     'passFailCriteria': {


### PR DESCRIPTION
Currently the `engineInstances` is set to 4 in bash and PowerShell.
Unfortunately "typical" subscription doesn't allow that, so I propose to reduce it to "1", to avoid:
```
Azure Load Testing dataplane returned different status code (400, was expecting 200 or 201) for test creation.\n{"statusCode": 400,
"exitCode": 0,
"body": "{\"error\":{\"code\":\"QuotaExceeded\",\"message\":\"Operation could not be completed as it results in exceeding the quota of 1 maxEngineInstancesPerTestRun per subscription in the region East US. Please create a support ticket to increase the limit.\",\"target\":null,\"details\":null}}"}
````

Thanks goes to Adam Marczak!