### PR TITLE
detect MacOS and use appropriate date parameters

### DIFF
--- a/056-CosmicTroubleshooting/Student/Resources/Challenge00/deploy.sh
+++ b/056-CosmicTroubleshooting/Student/Resources/Challenge00/deploy.sh
@@ -173,7 +173,13 @@ fi
 echo "Waiting for test plan validation by Azure..."
 
 runtime="2 minute"
-endtime=$(date -ud "$runtime" +%s)
+if [[ $OSTYPE == 'darwin'* ]]; then
+  # MacOS
+  endtime=$(date -v +2M +%s)
+else
+  # Other Linux distributions
+  endtime=$(date -ud "$runtime" +%s)
+fi
 
 testPlanStatus="VALIDATION_INITIATED";
 


### PR DESCRIPTION
MacOS has no `--ud` parameter for the `date` function so it defines enddate as an empty value. Because of that the next loop immediately completes and shows 'timeout' because it doesn't have proper enddate variable defined.

