### PR TITLE
Added minLength property to ARM template

### DIFF
--- a/001-IntroToKubernetes/Student/Resources/Challenge-01/build-machine/docker-build-machine-vm.json
+++ b/001-IntroToKubernetes/Student/Resources/Challenge-01/build-machine/docker-build-machine-vm.json
@@ -17,8 +17,9 @@
     },
     "adminPassword": {
       "type": "securestring",
+      "minLength": 12,
       "metadata": {
-        "description": "Password for the Virtual Machine."
+        "description": "Password for the Virtual Machine. That is 12 characters or more, with both uppercase, lowercase, numerical and special characters!"
       }
     },
     "ubuntuOSVersion": {


### PR DESCRIPTION
This ensures the password length is 12 characters or more, if you provide a shorter password, the machine is created, but no password is set, and in order to follow the next step in the hack, you need to either delete the deployment, and make sure to redeploy with a correct length password, or change the password in the Azure Portal. This little change helps the user not make this mistake, sadly I could not find any means of validating the password complexity - ARM templates doesn't seem to have this feature, at least not to my knowledge.