### PR TITLE
[Hack Update] 033-OSSDBs - Changed database pods to be internal to VNet and updated AKS version

### DIFF
--- a/033-OSSDatabaseMigration/Student/Resources/ARM-Templates/KubernetesCluster/parameters.json
+++ b/033-OSSDatabaseMigration/Student/Resources/ARM-Templates/KubernetesCluster/parameters.json
@@ -40,7 +40,7 @@
       "value": "ossdbmigration-dns"
     },
     "kubernetesVersion": {
-      "value": "1.25.5"
+      "value": "1.31.2"
     },
     "networkPlugin": {
       "value": "azure"

--- a/033-OSSDatabaseMigration/Student/Resources/HelmCharts/MySQL57/values.yaml
+++ b/033-OSSDatabaseMigration/Student/Resources/HelmCharts/MySQL57/values.yaml
@@ -18,7 +18,7 @@ image:
   tag: "5.7.32"
 
 service:
-  type: LoadBalancer
+  type: ClusterIP
   port: 3306
   protocol: TCP
 

--- a/033-OSSDatabaseMigration/Student/Resources/HelmCharts/Oracle184/values.yaml
+++ b/033-OSSDatabaseMigration/Student/Resources/HelmCharts/Oracle184/values.yaml
@@ -18,7 +18,7 @@ image:
   tag: "18.4.0-xe"
   
 service:
-  type: LoadBalancer
+  type: ClusterIP
   port: 1521
   protocol: TCP
 

--- a/033-OSSDatabaseMigration/Student/Resources/HelmCharts/Oracle21c/values.yaml
+++ b/033-OSSDatabaseMigration/Student/Resources/HelmCharts/Oracle21c/values.yaml
@@ -18,7 +18,7 @@ image:
   tag: "21.3.0-xe"
   
 service:
-  type: LoadBalancer
+  type: ClusterIP
   port: 1521
   protocol: TCP
 

--- a/033-OSSDatabaseMigration/Student/Resources/HelmCharts/PostgreSQL116/values.yaml
+++ b/033-OSSDatabaseMigration/Student/Resources/HelmCharts/PostgreSQL116/values.yaml
@@ -18,7 +18,7 @@ image:
   tag: "11.6"
 
 service:
-  type: LoadBalancer
+  type: ClusterIP
   port: 5432
   protocol: TCP
 


### PR DESCRIPTION
Changed the behavior of the database pods to be internal to the Vnet instead of having an external IP address. Also updated the AKS version to the latest. 