### PR TITLE
update to use cni with overlay as default networking for challenge 3

### DIFF
--- a/001-IntroToKubernetes/.wordlist.txt
+++ b/001-IntroToKubernetes/.wordlist.txt
@@ -1,0 +1,2 @@
+CoreDNS
+tunnelfront

--- a/001-IntroToKubernetes/Coach/Solution-03.md
+++ b/001-IntroToKubernetes/Coach/Solution-03.md
@@ -10,8 +10,9 @@
 	- The default Kubernetes version used by the az aks create command should be fine.  
 	- The CLI should be used to create the cluster to give the most realistic experience.  
 	- Cluster names should be unique within the subscription.  
-	- Here’s an example command that creates a cluster named **wth-aks02-poc** in resource group **wth-rg02-poc:** using basic networking, managed identity, 3 nodes in separate availability zones and an attached ACR and doesn't generate any ssh keys:
+	- Here’s an example command that creates a cluster named **wth-aks02-poc** in resource group **wth-rg02-poc:** using CNI networking (the default mode as of 1.30), managed identity, 3 nodes in separate availability zones and an attached ACR and doesn't generate any ssh keys:
 		- `az aks create --location eastus --name wth-aks02-poc --node-count 3  --no-ssh-key --resource-group wth-rg02-poc --zones 1 2 3 --enable-managed-identity --attach-acr <acrname>`
+	- Do mention that the network plugin can be changed using the `--network-plugin` argument, e.g., `--network-plugin azure` or `--network-plugin kubenet`. This is often encouraged to explicitly set this as opposed to using an implicit default.
   	- **NOTE:** Attaching an ACR requires the student to have Owner or Azure account administrator role on the Azure subscription. If this is not possible then someone who is an Owner can do the attach for the student after they create the cluster.
 		- See below for the `az aks update` command that is used to attach the ACR.
 	- Documentation on installing AKS can be found here:

--- a/001-IntroToKubernetes/Student/Challenge-03.md
+++ b/001-IntroToKubernetes/Student/Challenge-03.md
@@ -14,7 +14,7 @@ In this challenge we will be provisioning our first Kubernetes cluster using the
 	- **Hint:** This can be done easily with the Azure CLI
 - Use the Azure CLI to create a new, multi-node AKS cluster with the following specifications:
 	- Use the default Kubernetes version used by AKS.
-	- The cluster should use kubenet (ie: basic networking).  
+	- The cluster should use Azure CNI Overlay.  
 	- The cluster should use a managed identity
 	- The cluster should use the maximum number of Availability Zones for improved worker node reliability.
 	- The cluster should attach to your ACR created in Challenge 2 (if you didn't do Challenge 2, you don't need to attach to anything).
@@ -33,7 +33,7 @@ Once the cluster is running:
 1. The kubectl CLI is installed.
 1. Show that a new, multi-node AKS kubernetes cluster exists.
 1. Show that its nodes are running in multiple availability zones.
-1. Show that it is using basic networking (kubenet)
+1. Show that it is using CNI networking (CNI with overlay)
 
 ## Learning Resources
 


### PR DESCRIPTION
Updated content to reflect that Azure CNI w/ overlay is now the default networking plugin instead of kubenet. This applies to new clusters version 1.30 and higher. 