### PR TITLE
[HACK UPDATE] 066-Fundamentals of AI - Fix comments and enhance .env file backup logic in deploy script

### DIFF
--- a/066-OpenAIFundamentals/Student/Resources/infra/deploy.sh
+++ b/066-OpenAIFundamentals/Student/Resources/infra/deploy.sh
@@ -18,7 +18,7 @@ userObjectId=$(az ad signed-in-user show --query id --output tsv)
 
 parse_args variables $@
 
-# Validates if the resource group exists in the subscription, if not creates it
+# Validates if the resource group exists in the subscription, if not, it creates it
 echo "Checking if [$resourceGroupName] resource group exists in the [$subscriptionName] subscription..."
 az group show --name $resourceGroupName &>/dev/null
 
@@ -107,7 +107,16 @@ fi
 # Create the .env file
 echo -e "\n- Creating the .env file:"
 environment_file="../.env"
-environment_sample_file="../.env.sample"  
+environment_sample_file="../.env.sample"
+
+# check if the .env file already exists and back it up if it does
+    if [[ -f "$environment_file" ]]; then
+        random_chars=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 5)
+        cp "$environment_file" "${environment_file}-${random_chars}.bak"
+        echo -e "\e[33mWarning: Existing .env file found. Backed up to ${environment_file}-${random_chars}.bak\e[0m"
+    else
+        touch $environment_file
+    fi
   if [[ ! -f "$environment_sample_file" ]]; then
       error_exit "Example .env.sample file not found at $environment_sample_file."
   fi


### PR DESCRIPTION
This pull request introduces a safeguard to the deployment script to prevent accidental overwrites of the `.env` file, along with a minor clarification in a comment. The main improvement is the addition of logic to back up any existing `.env` file before creating a new one.

Environment file handling:

* Added logic to check if the `.env` file exists before creating it; if it does, the script now backs up the existing file with a random suffix to prevent data loss and notifies the user. (`066-OpenAIFundamentals/Student/Resources/infra/deploy.sh`)

Documentation:

* Clarified a comment to specify that the resource group will be created if it does not exist. (`066-OpenAIFundamentals/Student/Resources/infra/deploy.sh`)