### PR TITLE
docs: fix common English typos

### DIFF
--- a/002-IntroToAzureAI/Coach/Solutions/Challenge-2.4-Testing-Bots/Docs/2_Unit_Testing_Bots.md
+++ b/002-IntroToAzureAI/Coach/Solutions/Challenge-2.4-Testing-Bots/Docs/2_Unit_Testing_Bots.md
@@ -67,7 +67,7 @@ A.   Write another TestMethod called *EchoStartsWith* that verifies echo prompt 
 
 B.   Can you verify that the echoed messages were sent by a bot?
 
-*Hint:* This would involve checking the properties of IMessageActivity response recieved.
+*Hint:* This would involve checking the properties of IMessageActivity response received.
 
 
  ### Continue to [3_Direct_Line_Testing](3_Direct_Line_Testing.md)

--- a/002-IntroToAzureAI/Student/Resources/Challenge-2.4-Testing-Bots/docs/2_Unit_Testing_Bots.md
+++ b/002-IntroToAzureAI/Student/Resources/Challenge-2.4-Testing-Bots/docs/2_Unit_Testing_Bots.md
@@ -67,7 +67,7 @@ A.   Write another TestMethod called *EchoStartsWith* that verifies echo prompt 
 
 B.   Can you verify that the echoed messages were sent by a bot?
 
-*Hint:* This would involve checking the properties of IMessageActivity response recieved.
+*Hint:* This would involve checking the properties of IMessageActivity response received.
 
 
  ### Continue to [3_Direct_Line_Testing](3_Direct_Line_Testing.md)

--- a/037-AzureVirtualDesktop/Coach/10-Monitor-Manage-Performance-Health.md
+++ b/037-AzureVirtualDesktop/Coach/10-Monitor-Manage-Performance-Health.md
@@ -18,7 +18,7 @@ Students should be able to demonstrate a number of key elements to be successful
     - Recommended Windows Event Logs from their Windows Virtual Desktop session hosts 
     - [Configuration of Workbook requirements](https://docs.microsoft.com/en-us/azure/virtual-desktop/azure-monitor#set-up-using-the-configuration-workbook)
 - Students should configure the Azure Monitor Agent and enable all required counters [Azure Monitor for AVD documentation](https://docs.microsoft.com/en-us/azure/virtual-desktop/azure-monitor). 
-- Data typically flows within a few minutes of enabling the agent and counters however only new data will be received so testing should occur after confirmation that some data is being recieved by Log Analytics.
+- Data typically flows within a few minutes of enabling the agent and counters however only new data will be received so testing should occur after confirmation that some data is being received by Log Analytics.
 - Enabling alerts is an optional feature and not required for the purpose of this challenge however in operational environments it is recommend after baselines of the environment are performed. We don't offer fixed guidance on what alerts should be enabled today however the below links offer some suggestions and guidance on what customers may consider in a real environment.
 
 **Sample Queries**


### PR DESCRIPTION
## What

Fixes common English typos in documentation files.

## Changes

- `002-IntroToAzureAI/Coach/Solutions/Challenge-2.4-Testing-Bots/Docs/2_Unit_Testing_Bots.md` — `recieved` → `received` (1 occurrence)
- `037-AzureVirtualDesktop/Coach/10-Monitor-Manage-Performance-Health.md` — `recieved` → `received` (1 occurrence)
- `002-IntroToAzureAI/Student/Resources/Challenge-2.4-Testing-Bots/docs/2_Unit_Testing_Bots.md` — `recieved` → `received` (1 occurrence)

## Why

These are unambiguous English misspellings that slipped past review. The corrections are the widely-accepted English spellings:
- `recieve` / `recieved` / `recieving` → `receive` / `received` / `receiving` (common "ie"/"ei" reversal)
- `seperate` / `seperated` / `seperately` → `separate` / `separated` / `separately`
- `occured` / `occuring` / `occurence` → `occurred` / `occurring` / `occurrence`
- `begining` → `beginning`
- `succesful` / `succesfully` → `successful` / `successfully`
- `neccessary` → `necessary`
- `accomodate` → `accommodate`
- `overriden` → `overridden`
- `compatable` → `compatible`
- `cancelation` → `cancellation`
- `Pallete` → `Palette`

## Testing

- Documentation-only changes. No code affected.
- Each change is a literal one-word replacement. Diff is trivial to review.
